### PR TITLE
Change damage logic

### DIFF
--- a/PI_xfse.py
+++ b/PI_xfse.py
@@ -71,13 +71,15 @@ class engine:
 		if type == 2 or type == 8: #Turboprop
 			if itt > self.max_ITT:
 				_diff=itt-self.max_ITT
-				self.chtDamage += _diff * 0.25
+				if _diff > 0:
+					self.chtDamage += _diff * 0.25
 			if mix > 0.25 and altitude < 1000:
 				self.mixtureDamage += 0.25
 		elif type == 4 or type == 5: #Jet
 			if itt > self.max_ITT:
 				_diff=itt-self.max_ITT
-				self.chtDamage += _diff * 0.25
+				if _diff > 0:
+					self.chtDamage += _diff * 0.25
 			if mix > 0.25 and altitude < 1000:
 				self.mixtureDamage += 0.25
 		else: #Reciprocating or other gets old method as default

--- a/PI_xfse.py
+++ b/PI_xfse.py
@@ -71,16 +71,14 @@ class engine:
 		if type == 2 or type == 8: #Turboprop
 			if itt > self.max_ITT:
 				_diff=itt-self.max_ITT
-				if _diff > 0:
-					self.chtDamage += _diff * 0.25
-			if mix > 0.25 and altitude < 1000:
+				self.chtDamage += _diff * 0.25
+			if mix > 0.25 and altitude < 1000: #Low altitude contamination
 				self.mixtureDamage += 0.25
 		elif type == 4 or type == 5: #Jet
 			if itt > self.max_ITT:
 				_diff=itt-self.max_ITT
-				if _diff > 0:
-					self.chtDamage += _diff * 0.25
-			if mix > 0.25 and altitude < 1000:
+				self.chtDamage += _diff * 0.25
+			if mix > 0.25 and altitude < 1000: #Low altitude contamination
 				self.mixtureDamage += 0.25
 		else: #Reciprocating or other gets old method as default
 			if rpm>0:

--- a/PI_xfse.py
+++ b/PI_xfse.py
@@ -38,9 +38,14 @@ class engine:
 		self.chtDamage=0
 		self.mixtureDamage=0
 
+	def propType(self):
+		_propType=[]
+		XPLMGetDatavi(XPLMFindDataRef("sim/aircraft/prop/acf_prop_type"), _propType, 0, self.numberOfEngines)
+		return _propType[self.engineNumber]
+	
 	def engineType(self):
 		_engineType=[]
-		XPLMGetDatavi(XPLMFindDataRef("sim/aircraft/prop/acf_prop_type"), _engineType, 0, self.numberOfEngines)
+		XPLMGetDatavi(XPLMFindDataRef("sim/aircraft/prop/acf_en_type"), _engineType, 0, self.numberOfEngines)
 		return _engineType[self.engineNumber]
 
 	def currentRPM(self):
@@ -711,7 +716,7 @@ class PythonInterface:
 			isBrake=XPLMGetDataf(XPLMFindDataRef("sim/flightmodel/controls/parkbrake"))
 			airspeed=XPLMGetDataf(XPLMFindDataRef("sim/flightmodel/position/groundspeed"))
 
-			if self.ACEngine[0].engineType() == 3 or self.ACEngine[0].engineType() == 5:
+			if self.ACEngine[0].propType() == 3 or self.ACEngine[0].propType() == 5:
 				isHeli = 1
 			else:
 				isHeli = 0

--- a/PI_xfse.py
+++ b/PI_xfse.py
@@ -164,9 +164,9 @@ class PythonInterface:
 
 		#register Custom commands
 		self.CmdServerConn  = XPLMCreateCommand("fse/server/connect",      "Login to FSE Server")
-		self.CmdWindowShow  = XPLMCreateCommand("fse/window/show",         "show FSE window")
-		self.CmdWindowHide  = XPLMCreateCommand("fse/window/hide",         "hide FSE window")
-		self.CmdWindowTogl  = XPLMCreateCommand("fse/window/toggle",       "toggle FSE window")
+		self.CmdWindowShow  = XPLMCreateCommand("fse/window/show",         "Show FSE window")
+		self.CmdWindowHide  = XPLMCreateCommand("fse/window/hide",         "Hide FSE window")
+		self.CmdWindowTogl  = XPLMCreateCommand("fse/window/toggle",       "Toggle FSE window")
 		self.CmdFlightStart = XPLMCreateCommand("fse/flight/start",        "Start flight")
 		self.CmdFlightCArm  = XPLMCreateCommand("fse/flight/cancelArm",    "Cancel flight")
 		self.CmdFlightCCon  = XPLMCreateCommand("fse/flight/cancelConfirm","Cancel flight confirm")
@@ -500,7 +500,7 @@ class PythonInterface:
 				print "[XFSE|Nfo] BTN Start flying"
 				return self.startFly()
 			elif (inParam1 == self.CancelFlyButton):
-				print "[XFSE|Nfo] BTN canel flight"
+				print "[XFSE|Nfo] BTN Cancel flight"
 				self.cancelFlight("Flight cancelled","")
 			elif (inParam1 == self.UpdateButton):
 				self.doUpdate()
@@ -706,7 +706,7 @@ class PythonInterface:
 				self.gsCheat+=1
 
 			if self.gsCheat>10:
-				self.cancelFlight("Excessive time compression used. Your flight has been cancelled")
+				self.cancelFlight("Excessive time compression used. Your flight has been cancelled.")
 
 			isBrake=XPLMGetDataf(XPLMFindDataRef("sim/flightmodel/controls/parkbrake"))
 			airspeed=XPLMGetDataf(XPLMFindDataRef("sim/flightmodel/position/groundspeed"))
@@ -721,13 +721,13 @@ class PythonInterface:
 
 			# converting values to integer for comparison.  values after decimal were unrelaiable for this purpose.
 			if((int(_fueltotal) * 0.95) > int(self.checkfuel)):
-				self.cancelFlight("Airborn refueling not allowed. Flight cancelled","")
+				self.cancelFlight("Airborne refueling not allowed. Flight cancelled.","")
 
 			self.checkfuel=XPLMGetDataf(XPLMFindDataRef("sim/flightmodel/weight/m_fuel_total"))
 
 			# flightTimer check
 			if(self.flightTimer < self.flightTimerLast):
-				self.cancelFlight("Aircraft changed or repositioned. Your flight has been cancelled","")
+				self.cancelFlight("Aircraft changed or repositioned. Your flight has been cancelled.","")
 			self.flightTimerLast=self.flightTimer
 
 			# flightTime calc
@@ -1098,7 +1098,7 @@ class PythonInterface:
 					
 			else:
 				print "[XFSE|Nfo] Lease time has ended, cancelling flight"
-				self.cancelFlight("Lease time has ended. Your flight has been cancelled. Sorry, you will have to re-fly this trip","")
+				self.cancelFlight("Lease time has ended. Your flight has been cancelled. Sorry, you will have to re-fly this trip.","")
 				
 	#############################################################
 	## Flight cancel function

--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ The plugin uses Sandy Barbour's [Python interface](http://www.xpluginsdk.org/pyt
 5. Unzip the contents of PythonInterface.zip into the "resources/plugins" folder of X-Plane
 6. Now you should have a "PythonInterface" folder in the "plugins" folder
 7. In the "plugins" folder create a "PythonScripts" folder
-8. Copy X-Economy (PI_xfse.py) to "folderPythonScripts"
+8. Copy X-Economy (PI_xfse.py) to the "PythonScripts" folder
 9. Start X-Plane
 10. From the "Plugins" menu choose "X-Economy"->"Open"
-11. Type your username and password, press "Start flight" (the weigth and fuel automatically set by the plugin!)
-12. You're ready for take off
+11. Type your username and password, press "Login"
+12. When ready, press "Start Flight" (the weight and fuel are automatically set by the plugin!)
+13. You're ready for take off!
+14. After landing, taxi to parking and set parking brake (V key by default) and shut down all engines.
 
 ...and of course, it's highly recommended to read the [FSE Manual](https://sites.google.com/site/fseoperationsguide/) :)
 
@@ -28,8 +30,7 @@ You will need to edit your planes in XPlane to match FSE's... Kinda the same pro
 
 1. In FSeconomy.com, find the plane you want to fly in the Home -> List of Aircraft page and make a note of the type of plane you want.
 2. Open X-Economy menu from Plugins and select "Set aircraft alias". Enter Aircraft name and press "Set"
-3. Prepare your flight as you normally do and go flight...
-4. After landing, taxi to parking and set parking brake (V key by default) and shut down all engines.
+3. The alias will be remembered when you use the same airplane in the future.
 
 
 # Time compression in x-plane


### PR DESCRIPTION
The logic for the CHT and mixture damage were previously discussed [on the forums](http://www.fseconomy.net/forum/xplane-10/6485-mixture-cht-damage). The server applies whatever the plugin sends, and the plugin does not differentiate between aircraft types. The CHT and mixture damage do not make sense for turbine aircraft, and in the case of mixture damage, there is an actual (virtual) cost to the owner at 100-hr check time. It's simple to write a plugin to reduce mixture below the damage threshold (which I have done), but this is not obvious or accessible to all users. Also, I recently got a CL30 that insists on pegging the mixture at 1.0, which overrides the plugin workaround. :fearful:

I updated the function here to take into account the engine type, applying new rules for turbine aircraft, and leaving the old rules for anything else. Mixture damage is applied at low altitudes as a representation of contamination, but could be changed/removed if that seems unrealistic. CHT damage is based on the ITT limits, which may not always be reliable, but this damage doesn't have any tangible effect on the airplane (since "cylinder compression" readings have no effect here, as far as I know).

I also made some minor spelling/punctuation changes.